### PR TITLE
Buttons refactored into Controls component to be reused and demographics component styling in progress

### DIFF
--- a/raheem/src/components/Demographics.js
+++ b/raheem/src/components/Demographics.js
@@ -1,25 +1,102 @@
 import React from 'react';
+import styled from 'styled-components';
 
-//validation
+/* validation */
 import { useForm } from 'react-hook-form';
 
-//antd icons and components
+/* antd icons and components */
 import { Progress } from 'antd';
+import Controls from './buttons/Controls';
+import Continue from './buttons/Continue';
+import GoBack from './buttons/GoBack';
+import Save from './buttons/Save';
 
-//this function collects information about the users
+/* this function collects information about the users */
 function Demographics() {
 
     const { register, handleSubmit, errors } = useForm();
     const onSubmit = data => { console.log(data) }
 
     return (
-        <div>
-            <form onSubmit={handleSubmit(onSubmit)} style={{ width: "50%", display: "flex", flexDirection: "column" }}>
+        <DemographicsContainer>
+
+            <h2>About you</h2>
+            <p className="description">Help us understand how police treat people like you.</p>
+
+            <form onSubmit={handleSubmit(onSubmit)}>
+
+                {/* RACE */}
+                <h3>Your Race</h3>
+                <span>Required</span>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="asian" />
+                    Asian
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="african american" />
+                    Black/African
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="latinx" />
+                    Latinx
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="middle eastern" />
+                    Middle Eastern
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="native american" />
+                    Native American
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="pacific islander" />
+                    Pacific Islander
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="south asian" />
+                    South Asian
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="white" />
+                    White
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="multiracial" />
+                    Multiracial
+                </div>
+                <div>
+                    <input name="race" type="radio" ref={register({ required: true })} value="no preference" />
+                    Prefer not to say
+                </div>
+
+                {errors.race && <p>Please select your race.</p>}
+
+                {/* GENDER */}
+                <h3>Gender</h3>
+                <select name="gender" ref={register({ required: true })}>
+                    <option value="">Select...</option>
+                    <option value="female">Female</option>
+                    <option value="male">Male</option>
+                    <option value="variant non conforming">Gender Variant/Non Conforming</option>
+                    <option value="not listed">Not Listed</option>
+                    <option value="no preference">Prefer Not to Say</option>
+                    <option value="other">Other</option>
+                </select>
+                <span>Required</span>
+
+                {errors.gender && <p>Please select a gender.</p>}
+
+                <div>
+                    <input name="transgender" type="checkbox" ref={register} value="transgender" />
+                    I identify as trans
+                </div>
+
+                {errors.transgender && <p>This field is required.</p>}
 
                 {/* AGES */}
                 <label>What is your age?:</label>
                 <select name="age" ref={register({ required: true })}>
-                    <option value="">Select...</option>
+                    <option value="">Select Gender...</option>
                     <option value="18-24">18-24</option>
                     <option value="25-34">25-34</option>
                     <option value="35-44">35-44</option>
@@ -31,139 +108,112 @@ function Demographics() {
 
                 {errors.age && <p>Please select an age range.</p>}
 
-                {/* ETHNICITY */}
-                <label>Please specify your ethnicity:</label>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="african american" />
-                    African-American
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="asian" />
-                    Asian
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="caucasian" />
-                    Caucasian
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="hispanic" />
-                    Latino or Hispanic
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="native american" />
-                    Native American
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="hawaiian pacific islander" />
-                    Native Hawaiian or Pacific Islander
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="other" />
-                    Other
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="unknown" />
-                    Unknown
-                </div>
-                <div>
-                    <input name="ethnicity" type="radio" ref={register({ required: true })} value="no preference" />
-                    Prefer not to say
-                </div>
-
-                {errors.ethnicity && <p>Please select an ethnicity.</p>}
-
-                <label>What gender do you identify as?:</label>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="female" />
-                    Female
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="male" />
-                    Male
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="variant non conforming" />
-                    Gender Variant/Non-Conforming
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="not listed" />
-                    Not listed
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="no preference" />
-                    Prefer not to say
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="other" />
-                    Other
-                </div>
-
-                {errors.gender && <p>Please select a gender.</p>}
-
-                <label>Do you consider yourself to be:</label>
-                <div>
-                    <input name="sexuality" type="radio" ref={register({ required: true })} value="heterosexual" />
-                    Heterosexual or straight
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="homosexual" />
-                    Homosexual
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="bisexual" />
-                    Bisexual
-                </div>
-                <div>
-                    <input name="gender" type="radio" ref={register({ required: true })} value="other" />
-                    Other
-                </div>
-
-                {errors.gender && <p>Please select a sexuality.</p>}
-
-                <label>Do you consider yourself to be transgender?:</label>
-                <div>
-                    <input name="transgender" type="radio" ref={register({ required: true })} value="yes" />
-                    Yes
-                </div>
-                <div>
-                    <input name="transgender" type="radio" ref={register({ required: true })} value="no" />
-                    No
-                </div>
-
-                {errors.transgender && <p>This field is required.</p>}
-
                 <input type="submit" />
+
+                {/* pass down the path to the next page through props */}
+                <Controls next="/subscribe" />
+
+                <div className="progressContainer">
+                    <Progress
+                        strokeColor={{
+                            '0%': '#FFF600',
+                            '100%': '#111111',
+                        }}
+                        percent={75}
+                    />
+                </div>
             </form>
-
-            <div className="tagsButtonContainer">
-                <div>
-                    <p>Click here to proceed.</p>
-                    <Continue />
-                    {/* continue to subscription */}
-                </div>
-                <div>
-                    <p>Click here to go back.</p>
-                    <GoBack />
-                    {/* go back to story */}
-                </div>
-                <div>
-                    <p>Click here to save your responses and come back later.</p>
-                    <Save />
-                    {/* go to email */}
-                </div>
-            </div>
-
-            <div className="progressContainer">
-                <Progress
-                    strokeColor={{
-                        '0%': '#FFF600',
-                        '100%': '#111111',
-                    }}
-                    percent={75}
-                />
-            </div>
-        </div>
+        </DemographicsContainer>
     )
 }
 
 export default Demographics;
+
+/* container style for demographics component */
+const DemographicsContainer = styled.div`
+    margin: 5rem 0;
+    font-family: 'Noto Serif', serif;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    // Top heading
+    h2 {
+        font-family: 'Roboto', sans-serif;
+        font-weight: 900;
+        font-size: 4rem;
+    }
+
+    // Top heading tagline
+    p.description {
+        font-size: 2rem;
+        margin: 1rem 0;
+    }
+
+    // Form heading
+    h3 {
+        font-family: 'Roboto', sans-serif;
+        font-weight: 900;
+        font-size: 2.5rem;
+        margin-top: 3rem;
+    }
+
+    // Required field span
+    span {
+        font-size: 1.4rem;
+        margin: 0.5rem 0 2rem;
+    }
+
+    // Form styling
+    form {
+        background: #ffffff;
+        margin: 2rem 0;
+        padding: 3rem 2rem;
+        display: flex;
+        flex-direction: column;
+        padding: 0 10%;
+        width: 80%;
+
+        // Content and field separation within form
+        div {
+            font-family: 'Roboto', sans-serif;
+            font-size: 2rem;
+            font-weight: 900;
+            margin: 1rem 0;
+            display: flex;
+            align-items: center;
+        }
+
+        // Radio button styling
+        input[type=radio] {
+            height: 3rem;
+            width: 10%;
+            margin-right: 1rem;
+        }
+
+        // Select input styling
+        select {
+            margin: 1rem 0 0.5rem;
+        }
+
+        // Submit button styling
+        input[type=submit] {
+            font-family: 'Noto Serif', serif;
+            font-weight: 700;
+            font-size: 2rem;
+            border: none;
+            border-radius: 0.5rem;
+            background: #FFF600;
+            padding: 0.5rem 1rem;
+            transition: all 300ms;
+            margin: 3rem 0 0;
+
+            &:hover {
+                transition: background 300ms;
+                background: #FAEB00;
+                cursor: pointer;
+            }
+        }
+    }
+`;

--- a/raheem/src/components/StopDetails.js
+++ b/raheem/src/components/StopDetails.js
@@ -1,5 +1,11 @@
 import React from 'react';
 
+/* components */
+import Tags from './Tags';
+import Continue from './buttons/Continue';
+import GoBack from './buttons/GoBack';
+import Save from './buttons/Save';
+
 function StopDetails() {
     return (
         <div>

--- a/raheem/src/components/Story.js
+++ b/raheem/src/components/Story.js
@@ -3,6 +3,11 @@ import React from "react";
 //form validation
 import { useForm } from "react-hook-form";
 
+/* components */
+import Continue from './buttons/Continue';
+import GoBack from './buttons/GoBack';
+import Save from './buttons/Save';
+
 function Story() {
 
     const { handleSubmit, register, errors } = useForm();
@@ -21,10 +26,10 @@ function Story() {
                     <input
                         name="story"
                         ref={register({
-                        required: 'Required',
-                        pattern: {
-                            message: "input is required"
-                        }
+                            required: 'Required',
+                            pattern: {
+                                message: "input is required"
+                            }
                         })}
                     />
                     {errors.email && errors.email.message}

--- a/raheem/src/components/Tags.js
+++ b/raheem/src/components/Tags.js
@@ -1,76 +1,76 @@
-import React, { useState, useEffect } from "react";
+// import React, { useState, useEffect } from "react";
 
-//antd components
-import { Progress, Tag } from 'antd';
+// //antd components
+// import { Progress, Tag } from 'antd';
 
-//styles
-import styled from 'styled-components';
+// //styles
+// import styled from 'styled-components';
 
-//buttons
-import Continue from './buttons/Continue.js';
-import GoBack from './buttons/GoBack.js';
-import Save from './buttons/Save.js';
+// //buttons
+// import Continue from './buttons/Continue.js';
+// import GoBack from './buttons/GoBack.js';
+// import Save from './buttons/Save.js';
 
-//setting state  
-const { CheckableTag } = Tag;
-const [ checked, setChecked] = useState(false)
-const [ positive, setPositive] = useState()
-const [ negative, setNegative] = useState
+// //setting state  
+// const { CheckableTag } = Tag;
+// const [ checked, setChecked] = useState(false)
+// const [ positive, setPositive] = useState()
+// const [ negative, setNegative] = useState
 
-//setting checked tags to true
-const handleChange = checked => {
-    setChecked(true);
-};
+// //setting checked tags to true
+// const handleChange = checked => {
+//     setChecked(true);
+// };
 
-//this component is used for displaying story tags 
-const Tags = (props) => {
+// //this component is used for displaying story tags 
+// const Tags = (props) => {
 
-    return (
-    <div>
-        <p>
-            {/* instructions to user to click on appropriate tags */}
-        </p>
+//     return (
+//     <div>
+//         <p>
+//             {/* instructions to user to click on appropriate tags */}
+//         </p>
 
-        <div>
-            {/* tags display */}
+//         <div>
+//             {/* tags display */}
 
-            <CheckableTag 
-                {...props} 
-                checked={ checked } 
-                onChange={ handleChange } 
-            />
+//             <CheckableTag 
+//                 {...props} 
+//                 checked={ checked } 
+//                 onChange={ handleChange } 
+//             />
 
-            {/* positive */}
-            <div>
-                <MyTag>Helped</MyTag>
-                <MyTag>Protected</MyTag>
-            </div>
+//             {/* positive */}
+//             <div>
+//                 <MyTag>Helped</MyTag>
+//                 <MyTag>Protected</MyTag>
+//             </div>
 
-            {/* negative */}
-            <div>
-                <MyTag>Physically Attacked</MyTag>
-                <MyTag>Disrespected</MyTag>
-                <MyTag>Wrongly Accused</MyTag>
-                <MyTag>Harrassed</MyTag>
-                <MyTag>Neglected</MyTag>
-                <MyTag>Profiled</MyTag>
-            </div>
-        </div>
-
-
+//             {/* negative */}
+//             <div>
+//                 <MyTag>Physically Attacked</MyTag>
+//                 <MyTag>Disrespected</MyTag>
+//                 <MyTag>Wrongly Accused</MyTag>
+//                 <MyTag>Harrassed</MyTag>
+//                 <MyTag>Neglected</MyTag>
+//                 <MyTag>Profiled</MyTag>
+//             </div>
+//         </div>
 
 
-        <div>
-            <Progress
-                strokeColor={{
-                    '0%': '#FFF600',
-                    '100%': '#111111',
-                }}
-                percent={20}  />
-                />
-        </div>
-    </div>
-    );
-};
 
-export default Tags;
+
+//         <div>
+//             <Progress
+//                 strokeColor={{
+//                     '0%': '#FFF600',
+//                     '100%': '#111111',
+//                 }}
+//                 percent={20}  />
+//                 />
+//         </div>
+//     </div>
+//     );
+// };
+
+// export default Tags;

--- a/raheem/src/components/buttons/Continue.js
+++ b/raheem/src/components/buttons/Continue.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 //css
 import '../../index.css';
@@ -8,9 +9,16 @@ import '../../index.css';
 import { CaretRightOutlined } from '@ant-design/icons';
 
 //button to continue in the application
-function Continue() {
-    return(
-        <button className="save">
+function Continue(props) {
+
+    const history = useHistory(); // bring history in using the useHistory hook from react-router-dom
+    const { next } = props; // desconstruct next from props
+
+    return (
+        <button onClick={(e) => {
+            e.preventDefault(); // prevent default refresh
+            history.push(`${next}`); // push the user to the next page - defined by props passed from demographics component
+        }} className="save">
             Continue <CaretRightOutlined />
         </button>
     )

--- a/raheem/src/components/buttons/Controls.js
+++ b/raheem/src/components/buttons/Controls.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+
+/* components */
+import Continue from './Continue';
+import GoBack from './GoBack';
+import Save from './Save';
+
+function Controls(props) {
+
+    const { next } = props;
+
+    return (
+        <ControlsContainer>
+            <div>
+                <Continue next={next} />
+                {/* continue to subscription */}
+            </div>
+            <div>
+                <GoBack />
+                {/* go back to story */}
+            </div>
+            <div>
+                <Save />
+                {/* go to email */}
+            </div>
+        </ControlsContainer>
+    )
+}
+
+export default Controls;
+
+const ControlsContainer = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-evenly;
+
+    div {
+        width: 30%;
+        display: flex;
+        align-items: center;  
+    }
+`;

--- a/raheem/src/components/buttons/GoBack.js
+++ b/raheem/src/components/buttons/GoBack.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 //css
 import '../../index.css';
@@ -9,9 +10,16 @@ import { CaretLeftOutlined } from '@ant-design/icons';
 
 //button to go to previous page in application
 function GoBack() {
+
+    /* bring history in using the useHistory hook from react-router-dom */
+    const history = useHistory();
+
     return (
-        <button className="save">
-        <CaretLeftOutlined /> Go Back
+        <button onClick={(e) => {
+            e.preventDefault(); // prevent default refresh
+            history.goBack(); // take the user back a step in their history
+        }} className="save">
+            <CaretLeftOutlined /> Go Back
         </button>
     )
 }

--- a/raheem/src/components/buttons/Save.js
+++ b/raheem/src/components/buttons/Save.js
@@ -1,12 +1,20 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import '../../index.css';
 
 import { SaveOutlined } from '@ant-design/icons';
 
 function Save() {
+
+    /* bring history in using the useHistory hook from react-router-dom */
+    const history = useHistory();
+
     return (
-        <button className="save">
-            <SaveOutlined /> Save For Later 
+        <button onClick={(e) => {
+            e.preventDefault(); // prevent default refresh
+            history.push(`/subscribe`); // push user to subscribe page to save submission
+        }} className="save">
+            <SaveOutlined /> Save For Later
         </button>
     )
 }

--- a/raheem/src/index.css
+++ b/raheem/src/index.css
@@ -1,6 +1,10 @@
 /* noto serif font - secondary font */
 @import url('https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&display=swap');
 
+/* robot temporary font until we get official font from stakeholder */
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700,900&display=swap');
+
+
 /* temporary CSS reset until Christopher adds in tailwind CSS styling */
 * {
   margin: 0;
@@ -10,18 +14,20 @@
 
 html {
   font-size: 62.5%;
+  background: #FFF600;
 }
 
 button.save {
   font-family: 'Noto Serif', serif;
   font-weight: 700;
-  font-size: 2.4rem;
+  font-size: 1.4rem;
   border: none;
   border-radius: 0.5rem;
   background: #FFF600;
-  line-height: 3.6rem;
   padding: 0.5rem 1rem;
   transition: all 300ms;
+  display: flex;
+  align-items: center;
 }
 
 button.save:hover {


### PR DESCRIPTION
The buttons used for continue, go back, and save have been refactored into a component named Controls, located in our `buttons` directory. Pass a `next=''` prop to Controls to dictate where the Continue button will take you using react-router-dom. 

Also working on styling for the demographics component per J's figma wire frames he showed during stand up.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
