### PR TITLE
Header desktop styling

### DIFF
--- a/raheem/src/App.js
+++ b/raheem/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 /* route */
@@ -11,15 +11,30 @@ import About from './components/About';
 import Story from './components/Story';
 import ThankYou from './components/ThankYou';
 import Test from './components/TestComponents/Test';
+import DesktopHeader from './components/layout/DesktopHeader';
 import Header from './components/layout/Header';
 import Report from './components/Report';
 import Email from './components/Email';
 
 function App() {
+  const [windowWidth, setWindowWidth ] = useState(window.innerWidth);
+
+  const handleWindowResize = () => {
+    setWindowWidth(window.innerWidth);
+  };
+
+  useEffect(() => {        
+    window.addEventListener('resize', handleWindowResize);         
+  },[]);
 
   return (
     <div>
-      <Header />
+
+      {windowWidth < 500 &&
+      <Header />}
+
+      {windowWidth > 500 &&
+      <DesktopHeader />}
 
       {/* routes using react-router-dom */}
       <Route exact path="/">

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -10,12 +10,6 @@ import { TopBar } from '../../styles/global';
 
 function DesktopHeader() {
 
-    const [toggle, setToggle] = useState(false);
-
-    const toggleMenu = () => {
-        setToggle(!toggle);
-    }
-
     return (
         <HeaderContainer>
             <TopBar />
@@ -26,12 +20,10 @@ function DesktopHeader() {
                     </Link>
                 </div>
 
-                <nav>                    
-                    <div className="navTags">
-                        <Link to="/">Search</Link>
-                        <Link to="/about">About</Link>
-                        <Link to="/report">Reports</Link>
-                    </div>
+                <nav className="navTags">
+                    <Link to="/">Search</Link>
+                    <Link to="/about">About</Link>
+                    <Link to="/report">Reports</Link>
                 </nav>
             </div>
         </HeaderContainer>
@@ -42,6 +34,9 @@ export default DesktopHeader;
 
 const HeaderContainer = styled.div`
     width: 100%;
+    display: flex;
+    justify-content: center;
+    border: 2px solid black;
 
     .header {
         width: 90%;
@@ -53,13 +48,14 @@ const HeaderContainer = styled.div`
         border-bottom: 1px solid #111111;
         padding-top: 1%;
         padding-bottom: 1%;
-        /* border: 2px solid red; */
+        border: 2px solid red;
 
         .logo {
             width: 15%;
             padding-left: 26px;
             padding-top: 33px;
             padding-bottom: 33px;
+            border: 2px solid blue;
         }
     
         nav {
@@ -68,38 +64,30 @@ const HeaderContainer = styled.div`
             display: flex;
             justify-content: center;
             align-items: center;
-            flex-direction: column;
-            padding-right: 5%;
-            /* border: 1px solid blue; */
-
-            div.navTags {
-                position: absolute;
-                right: 0;
+            padding-right: 25%;
+            border: 2px solid blue;
+    
+            a {
+                background: #ffffff;
                 display: flex;
-                /* border: 2px solid red; */
+                justify-content: center;
+                align-items: center;
+                height: 4rem;
+                width: 15rem;
+                text-decoration: none;
+                color: #111111;
+                font-family: 'Roboto', sans-serif;
+                font-size: 2.6rem;
+                font-weight: bold;
+                padding-left: 2rem;
+                line-height: 1.8rem;
+                transition: all 300ms;
+                align-self: center;
+                /* border: 1px solid black; */
     
-                a {
-                    background: #ffffff;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    height: 4rem;
-                    width: 15rem;
-                    text-decoration: none;
-                    color: #111111;
-                    font-family: 'Roboto', sans-serif;
-                    font-size: 2.6rem;
-                    font-weight: bold;
-                    padding-left: 2rem;
-                    line-height: 1.8rem;
-                    transition: all 300ms;
-                    align-self: center;
-                    /* border: 1px solid black; */
-    
-                    &:hover {
-                        transition: background 300ms;
-                        background: #F2F2F2;
-                    }
+                &:hover {
+                    transition: background 300ms;
+                    background: #F2F2F2;
                 }
             }
         }

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -12,9 +12,8 @@ function DesktopHeader() {
 
     return (
         <HeaderContainer>
-            <TopBar />
-            <div className="header">
-                <div className="logo">
+            <div className="desktopheader">
+                <div className="desktoplogo">
                     <Link to="/">
                         <img src={Logo} alt="Raheem Logo" />
                     </Link>
@@ -38,7 +37,7 @@ const HeaderContainer = styled.div`
     justify-content: center;
     border-bottom: 3px solid #111111;
 
-    .header {
+    .desktopheader {
         width: 90%;
         height: 100%;
         background: #ffffff;
@@ -48,7 +47,7 @@ const HeaderContainer = styled.div`
         padding-top: 1%;
         padding-bottom: 1%;
 
-        .logo {
+        .desktoplogo {
             width: 15%;
             padding-left: 26px;
             padding-top: 33px;
@@ -60,24 +59,24 @@ const HeaderContainer = styled.div`
             display: flex;
             justify-content: center;
             align-items: center;
-            padding-right: 1%;
+            padding-right: 8%;
+
+            /* border: 2px solid red; */
     
             a {
-                background: #ffffff;
                 display: flex;
-                justify-content: center;
+                justify-content: space-between;
                 align-items: center;
-                height: 4rem;
-                width: 15rem;
                 text-decoration: none;
                 color: #111111;
                 font-family: 'Roboto', sans-serif;
                 font-size: 2.6rem;
                 font-weight: bold;
-                padding-left: 2rem;
-                line-height: 1.8rem;
+                margin: 7%;
                 transition: all 300ms;
                 align-self: center;
+
+                /* border: 2px solid orange; */
     
                 &:hover {
                     transition: background 300ms;

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -4,12 +4,11 @@ import { Link } from 'react-router-dom';
 
 /* assets */
 import Logo from '../../assets/Logo.svg';
-import MenuOutlinedIcon from '@material-ui/icons/MenuOutlined';
 
 /* styles */
 import { TopBar } from '../../styles/global';
 
-function Header() {
+function DesktopHeader() {
 
     const [toggle, setToggle] = useState(false);
 
@@ -25,11 +24,9 @@ function Header() {
                     <Link to="/"><img src={Logo} alt="Raheem Logo" /></Link>
                 </div>
 
-                <nav>
-                    <MenuOutlinedIcon onMouseEnter={() => toggleMenu()} style={{ fontSize: '24px' }} />
-                    
+                <nav>                    
                     {toggle === true && 
-                    <div onMouseLeave={() => toggleMenu()} onClick={() => toggleMenu()} className="navigation">
+                    <div onMouseLeave={() => toggleMenu()} onClick={() => toggleMenu()} className="navTags">
                         <Link to="/">Home</Link>
                         <Link to="/QR">QR</Link>
                         <Link to="/landing">Landing</Link>
@@ -45,7 +42,7 @@ function Header() {
     )
 }
 
-export default Header;
+export default DesktopHeader;
 
 const HeaderContainer = styled.div`
     width: 100%;

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -21,21 +21,17 @@ function DesktopHeader() {
             <TopBar />
             <div className="header">
                 <div className="logo">
-                    <Link to="/"><img src={Logo} alt="Raheem Logo" /></Link>
+                    <Link to="/">
+                        <img src={Logo} alt="Raheem Logo" />
+                    </Link>
                 </div>
 
                 <nav>                    
-                    {toggle === true && 
-                    <div onMouseLeave={() => toggleMenu()} onClick={() => toggleMenu()} className="navTags">
-                        <Link to="/">Home</Link>
-                        <Link to="/QR">QR</Link>
-                        <Link to="/landing">Landing</Link>
+                    <div className="navTags">
+                        <Link to="/">Search</Link>
                         <Link to="/about">About</Link>
                         <Link to="/report">Reports</Link>
-                        <Link to="/story">Story</Link>
-                        {/* <Link to="/subscribe">Subscribe</Link> */}
-                        <Link to="/thank-you">Thank You</Link>
-                    </div>}
+                    </div>
                 </nav>
             </div>
         </HeaderContainer>
@@ -48,8 +44,8 @@ const HeaderContainer = styled.div`
     width: 100%;
 
     .header {
-        width: 100%;
-        height: 5rem;
+        width: 90%;
+        height: 100%;
         background: #ffffff;
         display: flex;
         justify-content: space-between;
@@ -57,38 +53,48 @@ const HeaderContainer = styled.div`
         border-bottom: 1px solid #111111;
         padding-top: 1%;
         padding-bottom: 1%;
+        /* border: 2px solid red; */
 
         .logo {
             width: 15%;
-            padding-left: 5%;
-            padding-top: 2px;
+            padding-left: 26px;
+            padding-top: 33px;
+            padding-bottom: 33px;
         }
     
-        nav.nOne {
+        nav {
             width: 20%;
+            height: 4.1rem;
             display: flex;
+            justify-content: center;
+            align-items: center;
             flex-direction: column;
-            align-items: flex-end;
             padding-right: 5%;
+            /* border: 1px solid blue; */
 
-            div.navigation {
+            div.navTags {
                 position: absolute;
                 right: 0;
-                margin-top: 4rem;
                 display: flex;
-                flex-direction: column;
+                /* border: 2px solid red; */
     
                 a {
                     background: #ffffff;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
                     height: 4rem;
                     width: 15rem;
                     text-decoration: none;
                     color: #111111;
                     font-family: 'Roboto', sans-serif;
-                    font-size: 1.4rem;
+                    font-size: 2.6rem;
+                    font-weight: bold;
                     padding-left: 2rem;
-                    line-height: 4rem;
+                    line-height: 1.8rem;
                     transition: all 300ms;
+                    align-self: center;
+                    /* border: 1px solid black; */
     
                     &:hover {
                         transition: background 300ms;

--- a/raheem/src/components/layout/DesktopHeader.js
+++ b/raheem/src/components/layout/DesktopHeader.js
@@ -36,7 +36,7 @@ const HeaderContainer = styled.div`
     width: 100%;
     display: flex;
     justify-content: center;
-    border: 2px solid black;
+    border-bottom: 3px solid #111111;
 
     .header {
         width: 90%;
@@ -45,27 +45,22 @@ const HeaderContainer = styled.div`
         display: flex;
         justify-content: space-between;
         align-items: center;
-        border-bottom: 1px solid #111111;
         padding-top: 1%;
         padding-bottom: 1%;
-        border: 2px solid red;
 
         .logo {
             width: 15%;
             padding-left: 26px;
             padding-top: 33px;
             padding-bottom: 33px;
-            border: 2px solid blue;
         }
     
         nav {
-            width: 20%;
             height: 4.1rem;
             display: flex;
             justify-content: center;
             align-items: center;
-            padding-right: 25%;
-            border: 2px solid blue;
+            padding-right: 1%;
     
             a {
                 background: #ffffff;
@@ -83,7 +78,6 @@ const HeaderContainer = styled.div`
                 line-height: 1.8rem;
                 transition: all 300ms;
                 align-self: center;
-                /* border: 1px solid black; */
     
                 &:hover {
                     transition: background 300ms;
@@ -93,3 +87,4 @@ const HeaderContainer = styled.div`
         }
     }
 `;
+

--- a/raheem/src/components/layout/Header.js
+++ b/raheem/src/components/layout/Header.js
@@ -67,7 +67,7 @@ const HeaderContainer = styled.div`
             padding-top: 2px;
         }
     
-        nav.nOne {
+        nav {
             width: 20%;
             display: flex;
             flex-direction: column;

--- a/raheem/src/components/layout/Header.js
+++ b/raheem/src/components/layout/Header.js
@@ -56,11 +56,26 @@ const HeaderContainer = styled.div`
         justify-content: space-between;
         align-items: center;
         border-bottom: 1px solid #111111;
+        padding-top: 1%;
+        padding-bottom: 1%;
+        /* border: 1px solid blue; */
+
+        @media (min-width: 1074px) {
+            height: 100%;
+        }
 
         .logo {
             width: 15%;
             padding-left: 5%;
             padding-top: 2px;
+            /* border: 1px solid red; */
+
+            @media (min-width: 1074px) {
+            width: 15%;
+            padding-left: 26px;
+            padding-top: 30px;
+            padding-bottom: 30px;
+            }
         }
     
         nav {
@@ -69,7 +84,11 @@ const HeaderContainer = styled.div`
             flex-direction: column;
             align-items: flex-end;
             padding-right: 5%;
-    
+
+            @media (min-width: 1074px) {
+                display: none;
+                }
+   
             div.navigation {
                 position: absolute;
                 right: 0;


### PR DESCRIPTION
# Description
Desktop styling for the Header.

Fixes # (issue)
Within the DesktopHeader.js file, the padding within the a tags section of the css (now removed) was causing the distortion of the mobile version of the page display. In it's place I've put in margin: 7% (line 75) and seems to function much better for both chrome and firefox. May need more experimenting for polishing up the styling, but for now submitting my current progress. No vendor prefixes added as of yet.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist
- [x] My code follows the style guidelines of this project
