### PR TITLE
deep equals back to shallow equals because Firebase

### DIFF
--- a/raheem/src/components/Dashboard/Dashboard.js
+++ b/raheem/src/components/Dashboard/Dashboard.js
@@ -27,7 +27,7 @@ export default function Dashboard() {
             .get()
             .then(function (querySnapshot) {
                 querySnapshot.forEach(function (doc) {
-                    if (doc.data().officerBadgeID === params.id) {
+                    if (doc.data().officerBadgeID == params.id) {
                         console.log(`RESPONSE `, doc.data());
                         setOfficer(doc.data());
                     }

--- a/raheem/src/components/Landing.js
+++ b/raheem/src/components/Landing.js
@@ -27,7 +27,7 @@ function Landing(props) {
             .get()
             .then(function (querySnapshot) {
                 querySnapshot.forEach(function (doc) {
-                    if (doc.data().officerBadgeID === params.id) {
+                    if (doc.data().officerBadgeID == params.id) {
                         setOfficer(doc.data());
                     }
                 })


### PR DESCRIPTION
OfficerID to params.id comparison must be a shallow equals == instead of deep equals === because Firebase doesn't accept the deep equals condition.

# Description

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
